### PR TITLE
Add input validation for Git commit messages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "git.inputValidation": true,
+  "git.inputValidationSubjectLength": 50,
+  "git.inputValidationLength": 72,
   "[rust]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "jinxdash.prettier-rust"


### PR DESCRIPTION
Long commit messages make it difficult to determine the change. 50 characters is a length which GitHub does not truncate and makes sure messages are concise and meaningful.

A line in the description should be a maximum of 72 characters, this prevents unnecessary wrapping.